### PR TITLE
Add R8 keep annotation library

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -10,6 +10,18 @@ libraries:
         {yaml_dir}/android-java/fetch_android_jar.sh {name}
       targets:
       - '11662386'
+    r8-keep-annotations:
+      type: singleFile
+      dir: r8-{name}-keepanno
+      filename: keepanno-annotations.jar
+      check_file: keepanno-annotations.jar
+      url: https://storage.googleapis.com/r8-releases/raw/{name}/keepanno-annotations.jar
+      targets:
+        - 8.3.37
+        - 8.3.36
+        - 8.2.47
+        - 8.2.42
+        - 8.2.33
   c:
     cs50:
       build_type: manual


### PR DESCRIPTION
R8 for Android performs shrinking, minification, and optimization. R8 will strip unused functions, meaning that running it in CE will generally result in no output. This library contains annotations that can guide code removal.